### PR TITLE
Remove bh as it was deprecated in 2021

### DIFF
--- a/list.go
+++ b/list.go
@@ -24,7 +24,6 @@ var Languages = map[string]Language{
 	"ba": {Code: "ba", Name: "Bashkir", NativeName: "Башҡорт теле"},
 	"be": {Code: "be", Name: "Belarusian", NativeName: "Беларуская мова"},
 	"bg": {Code: "bg", Name: "Bulgarian", NativeName: "Български език"},
-	"bh": {Code: "bh", Name: "Bihari", NativeName: "भोजपुरी"},
 	"bi": {Code: "bi", Name: "Bislama", NativeName: "Bislama"},
 	"bm": {Code: "bm", Name: "Bambara", NativeName: "Bamanankan"},
 	"bn": {Code: "bn", Name: "Bengali", NativeName: "বাংলা"},


### PR DESCRIPTION
Reference: https://iso639-3.sil.org/about/news/change-part-1-language-code

There are 6 other deprecated ISO 639-1 codes which already do not appear in the list: `in`, `iw`, `ji`, `jw`, `mo`, `sh`

Reference: https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes